### PR TITLE
Add EventScope HTML with in-browser PDF parsing

### DIFF
--- a/eventscope_pdf.html
+++ b/eventscope_pdf.html
@@ -1,0 +1,1124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>EventScope</title>
+
+  <!-- Google Charts + PapaParse -->
+  <script src="https://www.gstatic.com/charts/loader.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
+
+  <!-- PDF.js for in-browser PDF parsing -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.10.111/pdf.min.js"></script>
+  <script>
+    if(window.pdfjsLib){
+      window.pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.10.111/pdf.worker.min.js";
+    }
+  </script>
+
+  <!-- Font -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --bg-navy:#0f1f3a; --panel:#1c2a55; --border:#394c7a; --text:#f5f5f5;
+      --accent:#2196f3; --chart-bg:#ffffff;
+      --prev:#dc2626; --new:#16a34a;
+      --tab:#0b1730; --tab-active:#173265;
+      --pill-now:#16a34a; --pill-next:#3b82f6;
+    }
+    *{box-sizing:border-box}
+    body{margin:0;font-family:'Poppins',sans-serif;background:var(--bg-navy);color:var(--text);}
+    .container{max-width:1200px;margin:0 auto;padding:24px;}
+    h1{font-size:1.6rem;font-weight:600;margin:0 0 12px 0;}
+    .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:14px;margin-bottom:14px;}
+
+    /* controls */
+    .controls{display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin-bottom:12px;}
+    label{font-size:.9rem;opacity:.9}
+    input[type="file"],input[type="date"]{
+      background:var(--panel);border:1px solid var(--border);color:var(--text);
+      padding:6px 10px;border-radius:6px;font:inherit;font-size:.85rem;
+    }
+    input[type="file"]::-webkit-file-upload-button{
+      background:var(--accent);color:#fff;border:none;padding:5px 8px;border-radius:4px;cursor:pointer;font-size:.8rem;
+    }
+    button{
+      background:var(--accent);color:#fff;border:none;padding:6px 12px;border-radius:6px;
+      font-size:.85rem;cursor:pointer;transition:.18s ease;
+    }
+    button:hover{filter:brightness(1.08)}
+    button.secondary{background:transparent;border:1px solid var(--border);}
+    .spacer{flex:1}
+    .group{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+
+    /* tabs */
+    .tabs{display:flex;gap:8px;margin:12px 0;}
+    .tab-btn{
+      background:var(--tab);border:1px solid var(--border);color:#cfe0ff;
+      padding:8px 12px;border-radius:8px;cursor:pointer;font-size:.9rem;
+    }
+    .tab-btn.active{background:var(--tab-active);color:#fff;border-color:#3e59a1;}
+    .tab-content{display:none;}
+    .tab-content.active{display:block;}
+
+    /* timeline */
+    #timeline-wrapper{background:var(--chart-bg);border-radius:10px;padding:10px;margin-top:8px;}
+    #timeline{width:100%;height:70vh;min-height:400px;}
+    #timeline text { font-weight: 400 !important; }
+
+    .google-visualization-tooltip,
+    .google-visualization-tooltip *{
+      color:#000 !important;background:#fff !important;
+      font-family:'Poppins',sans-serif !important;font-size:12px !important;
+    }
+    .google-visualization-tooltip{
+      border:1px solid #cfcfcf !important;box-shadow:0 6px 18px rgba(0,0,0,.15) !important;border-radius:6px !important;
+    }
+
+    /* change log */
+    #changeLogNote {
+      background:#eef6ff;color:#1e3a8a;
+      padding:6px 10px;margin:10px 0;border-radius:6px;
+      font-size:.9rem;font-weight:500;
+    }
+    .company-header{font-size:1.2rem;font-weight:600;margin:14px 0 6px;}
+    .event-header{font-size:1rem;font-weight:500;margin:8px 0 4px 8px;color:#cbd5e1;}
+    .change-card{
+      background:#fff;color:#000;border:1px solid #ddd;border-radius:8px;
+      padding:10px;margin:6px 0 6px 16px;
+      box-shadow:0 2px 4px rgba(0,0,0,0.1);
+    }
+    .change-card h4{margin:0 0 6px;font-size:.95rem;color:#111;}
+    .change-card ul{margin:0;padding-left:16px;}
+    .change-card li{margin:2px 0;font-size:.85rem;}
+    .change-prev{color:var(--prev);font-weight:600;}
+    .change-new{color:var(--new);font-weight:700;}
+
+    /* --- Today's Forecast (restored styling) --- */
+    .forecast-card {
+      background:#1c2a55;
+      padding:16px;
+      border-radius:10px;
+      margin-bottom:20px;
+      border:1px solid #394c7a;
+    }
+    .forecast-card h3 {margin-top:0;font-size:1.2rem;}
+
+    .company-group {margin-bottom:14px;padding:12px;border-radius:8px;background:#223366;}
+    .company-name {font-size:1rem;font-weight:600;margin-bottom:8px;}
+    .event-block {margin-bottom:10px;padding:8px;border-radius:6px;background:#2a3c6e;}
+    .event-title {font-weight:500;margin-bottom:4px;}
+    .space-pill {background:#394c7a;padding:3px 8px;border-radius:14px;font-size:.8rem;margin-right:6px;}
+
+    .happening .section {margin-top:12px;}
+    .happening strong {font-size:1.05rem;}
+    .happening .now strong {color:#22c55e;}
+    .happening .next strong {color:#3b82f6;}
+    .happening-row {
+      display:flex;
+      justify-content:space-between;
+      padding:6px 0;
+      border-bottom:1px solid #394c7a;
+    }
+    .happening-row:last-child {border-bottom:none;}
+    .happening-row span {font-size:.9rem;}
+
+    .warnings-block {
+      background:#1c1c1c;border:1px solid #facc15;color:#facc15;border-radius:10px;padding:16px;margin-top:20px;
+    }
+    .warnings-block h3 {margin-top:0;font-size:1.2rem;}
+    .warning-box {margin-bottom:12px;padding:10px;border:1px solid #facc15;border-radius:6px;background:#2a2a1c;}
+    .warning-box:last-child {margin-bottom:0;}
+    .warning-box strong {display:block;color:#facc15;margin-bottom:4px;}
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <h1>EventScope</h1>
+
+    <!-- GLOBAL uploads (available on all tabs) -->
+    <div class="card" id="globalUploads">
+      <div class="controls">
+        <div class="group">
+          <label for="csvFileA">Newest Event Report (CSV or PDF)</label>
+          <input type="file" id="csvFileA" accept=".csv,.pdf" />
+        </div>
+        <div class="spacer"></div>
+        <div class="group">
+          <label for="csvFileB">Previous Event Report (CSV or PDF)</label>
+          <input type="file" id="csvFileB" accept=".csv,.pdf" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="timelineTab">Timeline</button>
+      <button class="tab-btn" data-tab="changeTab">Change Log</button>
+      <button class="tab-btn" data-tab="forecastTab">Today’s Forecast</button>
+    </div>
+
+    <!-- TIMELINE TAB -->
+    <div id="timelineTab" class="tab-content active">
+      <div class="card">
+        <div class="controls">
+          <div class="group">
+            <label for="dayPicker">Day</label>
+            <input type="date" id="dayPicker" />
+            <button id="prevDay" class="secondary">⬅ Prev</button>
+            <button id="nextDay">Next ➡</button>
+          </div>
+          <div class="spacer"></div>
+          <div class="group">
+            <button id="toggleShowRooms" class="secondary">Show All Rooms</button>
+          </div>
+        </div>
+        <div id="timeline-wrapper">
+          <div id="timeline"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CHANGE LOG TAB -->
+    <div id="changeTab" class="tab-content">
+      <div class="card">
+        <h2>Change Log</h2>
+        <div id="changeLogNote">Comparing: Previous Report → Newest Report</div>
+        <div id="changeLog">
+          <p style="opacity:.8">Upload both reports to see changes.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- TODAY'S FORECAST TAB -->
+    <div id="forecastTab" class="tab-content">
+      <div class="card">
+        <h2>Today’s Event Forecast</h2>
+        <div id="forecast">
+          <p style="opacity:.8">Upload the newest report to view today’s schedule summary.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  google.charts.load("current", { packages: ["timeline"] });
+
+  // --- Global state ---
+  let allEvents = [];
+  let currentDate = null;
+  let showAllRooms = false;
+  let reportA = [], reportB = []; // A = newest, B = previous
+
+  // --- PDF parsing heuristics (ported from parse_event_report.py) ---
+  const FUNCTION_TYPES = [
+    "Meeting","Breakout","Breakfast","Lunch","Dinner","Reception",
+    "Cocktail Reception","Board Meeting","General Session","Set Up",
+    "Holding Room","Dance","Ceremony","Brunch","Box Lunch",
+    "PM Break","AM Break","Coffee Break","Continuous Break",
+    "Hospitality Room","24 Hour Hold","Storage","Office",
+    "Registration","Rehearsal","Special","Buffet","Exhibits",
+    "Continental Breakfast","Teardown","No Agenda Hold"
+  ];
+
+  const FUNCTION_SPACES_HINTS = [
+    "Director's Room","The Founders Room",
+    "Legacy Ballroom","Legacy Ballroom I","Legacy Ballroom II",
+    "Legacy I","Legacy II","Legacy Prefunction",
+    "The Gallery","Gallery","Gallery I","Gallery II",
+    "Gallery Prefunction","Gallery I Prefunction","Gallery II Prefunction",
+    "The Gallery Lounge",
+    "Trade Root Restaurant","Boardroom","Envoy","Diplomat","Ambassador",
+    "Plaza I","Plaza II","Plaza III","Plaza II & III","Plaza","Plaza Prefunction",
+    "Salon I","Salon II","Salon III","Salon IV","Salon V",
+    "Salon VI","Salon VII","Salon VIII",
+    "Prefunction","2nd Floor Prefunction","Whitley Prefunction",
+    "Consulate","Delegate","Attache","Charge",
+    "The Whitley Ballroom","Whitley Ballroom"
+  ];
+
+  const SETUP_STYLES = [
+    "Conference","Rounds of 10","Rounds of 8","Rounds of 6",
+    "Chevron Theatre","Schoolroom","U-Shape","Hollow Square",
+    "Cocktail Rounds","Theatre","Special",
+    "Crescent Rounds","Lounge","Storage"
+  ];
+
+  const GROUPINGS = {
+    "Whitley Ballroom": ["Salon I","Salon II","Salon III","Salon IV","Salon V","Salon VI","Salon VII","Salon VIII"],
+    "Plaza Ballroom": ["Plaza I","Plaza II","Plaza III"],
+    "Legacy Ballroom": ["Legacy I","Legacy II"],
+  };
+
+  const ROMAN_ORDER = { I:1, II:2, III:3, IV:4, V:5, VI:6, VII:7, VIII:8 };
+
+  const MEAL_BREAK_TYPES = new Set([
+    "Breakfast","Lunch","Dinner","AM Break","PM Break",
+    "Coffee Break","Continuous Break","Box Lunch","Buffet","Continental Breakfast"
+  ]);
+
+  const FALLBACK_TYPES = new Set([...MEAL_BREAK_TYPES, "Meeting", "Rehearsal", "Exhibits"]);
+
+  const TIME_RANGE_RE = /(\d{1,2}:\d{2}\s?[AP]M)\s*[-–—]\s*(\d{1,2}:\d{2}\s?[AP]M)/i;
+  const DATE_LINE_RE = /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), .* \d{4}$/i;
+  const COUNTS_RE = /^\d+\/\d+\/(?:\d+|__)$/;
+  const POST_AS_RE = /Post As[:\-]?\s*(.+)/i;
+
+  function escapeRegExp(str){
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function romanToInt(r){
+    return ROMAN_ORDER[r] ?? 999;
+  }
+
+  function splitRomanList(str){
+    const cleaned = str.replace(/\s*(?:&|and)\s*/gi, ",");
+    return cleaned
+      .split(",")
+      .map(p=>p.trim().toUpperCase())
+      .filter(p=>p && /^[IVX]+$/.test(p));
+  }
+
+  function expandCompoundPrefix(lineText){
+    const found = new Set();
+    const checks = [
+      {prefix:"Salon", regex:/\bSalon\b\s+([IVX]+(?:\s*,\s*[IVX]+)*(?:\s*(?:&|and)\s*[IVX]+)?)/gi},
+      {prefix:"Plaza", regex:/\bPlaza\b\s+([IVX]+(?:\s*,\s*[IVX]+)*(?:\s*(?:&|and)\s*[IVX]+)?)/gi},
+      {prefix:"Legacy", regex:/\bLegacy\b\s+([IVX]+(?:\s*,\s*[IVX]+)*(?:\s*(?:&|and)\s*[IVX]+)?)/gi},
+    ];
+    checks.forEach(({prefix, regex})=>{
+      let match;
+      while((match = regex.exec(lineText))){
+        splitRomanList(match[1]).forEach(r=> found.add(`${prefix} ${r}`));
+      }
+    });
+    return Array.from(found);
+  }
+
+  function expandGroupedSpace(lineText, primary){
+    const compound = new Set(expandCompoundPrefix(lineText));
+
+    Object.entries(GROUPINGS).forEach(([ballroom, subs])=>{
+      subs.forEach(sub=>{
+        const re = new RegExp(`\\b${escapeRegExp(sub)}\\b`);
+        if(re.test(lineText)) compound.add(sub);
+      });
+    });
+
+    if(/\bAttache\b/i.test(lineText) && /\bCharge\b/i.test(lineText)){
+      return "Attache Charge";
+    }
+
+    if(!compound.size){
+      return primary ? primary.trim() : primary;
+    }
+
+    const whitley = Array.from(compound).filter(s=>s.startsWith("Salon "));
+    const plaza = Array.from(compound).filter(s=>s.startsWith("Plaza "));
+    const legacy = Array.from(compound).filter(s=>s.startsWith("Legacy "));
+
+    if(whitley.length){
+      const romans = Array.from(new Set(whitley.map(s=>s.split(" ").at(-1)))).sort((a,b)=>romanToInt(a)-romanToInt(b));
+      return `Whitley Ballroom (${romans.map(r=>`Salon ${r}`).join(", ")})`;
+    }
+    if(plaza.length){
+      const romans = Array.from(new Set(plaza.map(s=>s.split(" ").at(-1)))).sort((a,b)=>romanToInt(a)-romanToInt(b));
+      return `Plaza Ballroom (${romans.map(r=>`Plaza ${r}`).join(", ")})`;
+    }
+    if(legacy.length){
+      const romans = Array.from(new Set(legacy.map(s=>s.split(" ").at(-1)))).sort((a,b)=>romanToInt(a)-romanToInt(b));
+      return `Legacy Ballroom (${romans.map(r=>`Legacy ${r}`).join(", ")})`;
+    }
+
+    return primary ? primary.trim() : primary;
+  }
+
+  function detectFunctionType(text){
+    if(/\bContinental\b/i.test(text)) return "Continental Breakfast";
+    const sorted = [...FUNCTION_TYPES].sort((a,b)=>b.length-a.length);
+    for(const f of sorted){
+      const re = new RegExp(`\\b${escapeRegExp(f)}\\b`, "i");
+      if(re.test(text)) return f;
+    }
+    return null;
+  }
+
+  function detectSetupStyle(text){
+    const sorted = [...SETUP_STYLES].sort((a,b)=>b.length-a.length);
+    for(const s of sorted){
+      const re = new RegExp(`\\b${escapeRegExp(s)}\\b`, "i");
+      if(re.test(text)) return s;
+    }
+    return null;
+  }
+
+  function detectSpace(text){
+    for(const hint of FUNCTION_SPACES_HINTS){
+      const re = new RegExp(`\\b${escapeRegExp(hint)}\\b`);
+      if(re.test(text)) return hint;
+    }
+    return null;
+  }
+
+  function cleanTimeString(raw){
+    if(!raw) return "";
+    const match = raw.match(/(\d{1,2}):(\d{2})\s*([AP]M)/i);
+    if(!match) return raw.trim();
+    const hour = String(Number(match[1]));
+    const minute = match[2];
+    const mod = match[3].toUpperCase();
+    return `${hour}:${minute} ${mod}`;
+  }
+
+  // --- Room ordering (includes Attache Charge) ---
+  const ROOM_ORDER = [
+    "Whitley Ballroom","Whitley Prefunction",
+    "Salon I","Salon II","Salon III","Salon IV","Salon V","Salon VI","Salon VII","Salon VIII",
+    "Plaza Ballroom","Plaza Prefunction","Plaza I","Plaza II","Plaza III",
+    "Gallery","Gallery Prefunction","Gallery I","Gallery II",
+    "Legacy Ballroom","Legacy Prefunction","Legacy I","Legacy II",
+    "Ambassador","Attache","Attache Charge","Boardroom","Charge","Consulate",
+    "Delegate","Diplomat","Director's Room","Envoy","The Founders Room"
+  ];
+
+  const SUBORDER = {
+    "Whitley Ballroom": ["Salon I","Salon II","Salon III","Salon IV","Salon V","Salon VI","Salon VII","Salon VIII"],
+    "Plaza Ballroom":   ["Plaza I","Plaza II","Plaza III"],
+    "Legacy Ballroom":  ["Legacy I","Legacy II"],
+    "Gallery":          ["Gallery I","Gallery II"]
+  };
+  const PARENT_MAP = {};
+  Object.entries(SUBORDER).forEach(([parent, subs])=>{
+    subs.forEach(s => { PARENT_MAP[s] = parent; });
+  });
+
+  // ---------- Utils ----------
+  function condenseSubs(list){
+    if(!list.length) return "";
+    const m = list[0].match(/^([A-Za-z]+(?:\s[A-Za-z]+)?)\s+/);
+    let prefix = m ? m[1] + " " : "";
+    if(prefix && !list.every(x => x.startsWith(prefix))) prefix = "";
+    if(!prefix) return list.join(", ");
+    const rest = list.map(x => x.slice(prefix.length)).join(", ");
+    return prefix + rest;
+  }
+
+  function normalizeRooms(raw){
+    if(!raw) return [];
+    let s = String(raw).trim();
+    if(s==="The Whitley Ballroom") s="Whitley Ballroom";
+    if(s==="The Gallery") s="Gallery";
+    if(s==="Plaza") s="Plaza Ballroom";
+    if(s==="Founder's Room" || s==="Founders Room") s="The Founders Room";
+    if(s==="Legacy Ballroom I") s="Legacy I";
+    if(s==="Legacy Ballroom II") s="Legacy II";
+    if(s.toLowerCase()==="attache charge") return ["Attache Charge"];
+    if(s==="Prefunction") return ["Whitley Prefunction"];
+    // Parentheses notation → list
+    if(s.includes("(") && s.includes(")")){
+      const inner = s.slice(s.indexOf("(")+1, s.lastIndexOf(")")).trim();
+      if(inner) return inner.split(",").map(x=>x.trim());
+    }
+    // Comma-separated list
+    if(s.includes(",")) return s.split(",").map(p=>p.trim());
+    return [s];
+  }
+
+  function groupRoomsToLabels(rooms){
+    const byBase = new Map();
+    rooms.forEach(r=>{
+      const base = PARENT_MAP[r] || r;
+      const isSub = !!PARENT_MAP[r];
+      if(!byBase.has(base)) byBase.set(base, {base, subs:new Set()});
+      if(isSub) byBase.get(base).subs.add(r);
+    });
+    const out = [];
+    for(const {base,subs} of byBase.values()){
+      if(subs.size>0){
+        const all = SUBORDER[base] || [];
+        if(subs.size === all.length){
+          out.push({label: base, base});
+        }else{
+          let list = Array.from(subs);
+          if(all.length) list.sort((a,b)=>all.indexOf(a)-all.indexOf(b));
+          const condensed = condenseSubs(list);
+          out.push({label: `${base} (${condensed})`, base});
+        }
+      }else{
+        out.push({label: base, base});
+      }
+    }
+    return out;
+  }
+
+  function parseDayOfEvent(str){
+    if(!str) return null;
+    let d = new Date(str);
+    if(isNaN(d)) d = new Date(str.replace(/^[A-Za-z]+,\\s*/,""));
+    return isNaN(d) ? null : d;
+  }
+  function parseTime(str){
+    if(!str) return [0,0];
+    const parts = String(str).trim().split(" ");
+    const timePart = parts[0]||"0:00";
+    const mod = (parts[1]||"").toUpperCase();
+    const hhmm = timePart.split(":");
+    let h = Number(hhmm[0]||0), m = Number(hhmm[1]||0);
+    if(mod==="PM" && h<12) h+=12;
+    if(mod==="AM" && h===12) h=0;
+    return [h,m];
+  }
+  function formatAMPM(d){
+    let h=d.getHours(),m=d.getMinutes(),ampm=h>=12?"PM":"AM";
+    h=h%12; h=h?h:12; m=m<10?"0"+m:m;
+    return `${h}:${m} ${ampm}`;
+  }
+  function floorToHour(d){const x=new Date(d);x.setMinutes(0,0,0);return x;}
+  function ceilToHour(d){const x=new Date(d);x.setMinutes(0,0,0);if(d>x)x.setHours(x.getHours()+1);return x;}
+  function toLocalISODate(d){
+    return d.getFullYear()+"-"+String(d.getMonth()+1).padStart(2,"0")+"-"+String(d.getDate()).padStart(2,"0");
+  }
+  function sameDay(a,b){return a.getFullYear()===b.getFullYear()&&a.getMonth()===b.getMonth()&&a.getDate()===b.getDate();}
+
+  // ---------- Timeline ----------
+  function groupTooltip(room, items, status){
+    items.sort((a,b)=>a.start-b.start);
+    let html=`<div style="padding:6px; color:#000;">`;
+    if(items[0]?.event) html+=`<div style="font-weight:700; margin-bottom:4px;">${items[0].event}</div>`;
+    if(status) html+=`<div style="margin-bottom:6px"><span style="padding:2px 6px;border-radius:6px;background:#eef;border:1px solid #ccd">${status}</span></div>`;
+    html+=`<div style="font-weight:600; margin-bottom:4px;">${room}</div>`;
+    items.forEach(e=>{
+      const time=`${formatAMPM(e.start)} – ${formatAMPM(e.end)}`;
+      html+=`<div><b>${e.function||""}</b> · ${time} · ${e.setup||""}</div>`;
+    });
+    html+=`</div>`;
+    return html;
+  }
+
+  function drawChart(selectedDate){
+    const container = document.getElementById("timeline");
+    const chart = new google.visualization.Timeline(container);
+    const dataTable = new google.visualization.DataTable();
+
+    dataTable.addColumn({type:"string", id:"Room"});
+    dataTable.addColumn({type:"string", id:"Label"});
+    dataTable.addColumn({type:"string", role:"tooltip", p:{html:true}});
+    dataTable.addColumn({type:"string", role:"style"});
+    dataTable.addColumn({type:"date",  id:"Start"});
+    dataTable.addColumn({type:"date",  id:"End"});
+
+    const chosen = new Date(selectedDate + "T00:00:00");
+    currentDate = chosen;
+
+    const groups = {}; // key -> {roomLabel, base, company, status, items[], min, max}
+    let dataMin = null, dataMax = null;
+
+    (allEvents || []).forEach(ev=>{
+      const d = parseDayOfEvent(ev["Day of Event"]); if(!d) return;
+      const status = (ev["Event Status"]||"").toString().trim();
+      const [sh,sm] = parseTime(ev["Start Time"]);
+      const [eh,em] = parseTime(ev["End Time"]);
+      let start = new Date(d.getFullYear(), d.getMonth(), d.getDate(), sh, sm);
+      let end   = new Date(d.getFullYear(), d.getMonth(), d.getDate(), eh, em);
+      const rooms = normalizeRooms(ev["Function Space"]);
+      const company = ev["Company Name"]||"";
+      const eventName = ev["Event Name"]||"";
+      const labels = groupRoomsToLabels(rooms);
+
+      // Overnight split
+      if(end < start){
+        const midnight = new Date(start); midnight.setHours(23,59,59,999);
+        const nextDay = new Date(d); nextDay.setDate(d.getDate()+1);
+        const endNext = new Date(nextDay.getFullYear(), nextDay.getMonth(), nextDay.getDate(), eh, em);
+
+        labels.forEach(({label, base})=>{
+          if(sameDay(d, chosen)){
+            const key = label+"||"+company+"||"+status+"||"+d.toDateString();
+            if(!groups[key]) groups[key] = {roomLabel:label, base, company, status, items:[], min:start, max:midnight};
+            groups[key].items.push({event:eventName, function:ev["Function Type"], setup:ev["Setup Style"], start, end:midnight});
+            if(start < groups[key].min) groups[key].min = start;
+            if(midnight > groups[key].max) groups[key].max = midnight;
+            if(!dataMin || start < dataMin) dataMin = start;
+            if(!dataMax || midnight > dataMax) dataMax = midnight;
+          }
+          if(sameDay(nextDay, chosen)){
+            const key = label+"||"+company+"||"+status+"||"+nextDay.toDateString();
+            if(!groups[key]) groups[key] = {roomLabel:label, base, company, status, items:[], min:nextDay, max:endNext};
+            groups[key].items.push({event:eventName, function:ev["Function Type"], setup:ev["Setup Style"], start:nextDay, end:endNext});
+            if(nextDay < groups[key].min) groups[key].min = nextDay;
+            if(endNext > groups[key].max) groups[key].max = endNext;
+            if(!dataMin || nextDay < dataMin) dataMin = nextDay;
+            if(!dataMax || endNext > dataMax) dataMax = endNext;
+          }
+        });
+        return;
+      }
+
+      // Same-day
+      if(sameDay(d, chosen)){
+        labels.forEach(({label, base})=>{
+          const key = label+"||"+company+"||"+status+"||"+d.toDateString();
+          if(!groups[key]) groups[key] = {roomLabel:label, base, company, status, items:[], min:start, max:end};
+          groups[key].items.push({event:eventName, function:ev["Function Type"], setup:ev["Setup Style"], start, end});
+          if(start < groups[key].min) groups[key].min = start;
+          if(end > groups[key].max)   groups[key].max = end;
+        });
+        if(!dataMin || start < dataMin) dataMin = start;
+        if(!dataMax || end   > dataMax) dataMax = end;
+      }
+    });
+
+    const rows = [];
+    const usedBases = new Set();
+
+    ROOM_ORDER.forEach(roomBase=>{
+      Object.values(groups).forEach(g=>{
+        if(g.base === roomBase && sameDay(g.min, chosen)){
+          usedBases.add(roomBase);
+          rows.push([
+            g.roomLabel,
+            g.company || g.items[0]?.event || "",
+            groupTooltip(g.roomLabel, g.items, g.status),
+            "",
+            g.min, g.max
+          ]);
+        }
+      });
+      if(showAllRooms && !usedBases.has(roomBase)){
+        const base = dataMin || new Date(chosen.getFullYear(), chosen.getMonth(), chosen.getDate(), 8, 0);
+        rows.push([roomBase, "", "", "color:#E5E7EB;", base, new Date(base.getTime()+60000)]);
+      }
+    });
+
+    if(rows.length===0){
+      container.innerHTML = "<p style='color:#c00; margin:12px;'>No events found for this date.</p>";
+      return;
+    }
+
+    dataTable.addRows(rows);
+
+    const startHour = dataMin ? floorToHour(dataMin) : new Date(chosen.getFullYear(), chosen.getMonth(), chosen.getDate(), 0, 0);
+    const endHour   = dataMax ? ceilToHour(dataMax)   : new Date(chosen.getFullYear(), chosen.getMonth(), chosen.getDate(), 23, 59);
+    const ticks = [];
+    let t = new Date(startHour);
+    while(t <= endHour){
+      ticks.push(new Date(t.getTime()));
+      t.setHours(t.getHours()+1);
+    }
+    const pad = 60 * 1000;
+
+    chart.draw(dataTable, {
+      tooltip:{isHtml:true, trigger:"focus"},
+      backgroundColor:{fill:"#fff"},
+      chartArea:{backgroundColor:"#fff"},
+      hAxis:{
+        ticks,
+        viewWindow:{ min:new Date(startHour.getTime()-pad), max:new Date(endHour.getTime()+pad) },
+        format:"h a",
+        textStyle:{color:"#000",bold:false},
+        baselineColor:"#aaa",
+        gridlines:{color:"#ddd"},
+        minorGridlines:{count:0}
+      },
+      timeline:{
+        showBarLabels:true,
+        rowLabelStyle:{fontSize:13, color:"#000"},
+        barLabelStyle:{fontSize:11, color:"#000"}
+      }
+    });
+  }
+
+  // ---------- Change Log ----------
+  function generateChangeLog(reportA, reportB){
+    const container = document.getElementById("changeLog");
+    container.innerHTML = "";
+
+    if(!reportA.length || !reportB.length){
+      container.innerHTML = "<p style='opacity:.8'>Upload both reports to see changes.</p>";
+      return;
+    }
+
+    // Company + Event + Date + Room + Function Type + Post As
+    const makeKey = ev => [
+      ev["Company Name"], ev["Event Name"], ev["Day of Event"],
+      ev["Function Space"], ev["Function Type"], ev["Post As"] || ""
+    ].join("||");
+
+    const mapB = new Map();
+    reportB.forEach(ev=> mapB.set(makeKey(ev), ev));
+
+    const companyGroups = {};
+    reportA.forEach(ev=>{
+      const key = makeKey(ev);
+      const old = mapB.get(key);
+      if(!old) return; // only overlapping entries
+
+      const diffs = [];
+      ["Start Time","End Time","Setup Style","Event Status"].forEach(field=>{
+        if((ev[field]||"").trim() !== (old[field]||"").trim()){
+          diffs.push({field, prev: old[field]||"", newest: ev[field]||""});
+        }
+      });
+
+      if(diffs.length){
+        const company = ev["Company Name"]||"";
+        const event   = ev["Event Name"]||"";
+        const space   = ev["Function Space"]||"";
+        const ftype   = ev["Function Type"]||"";
+        const pas     = ev["Post As"]||"";
+        if(!companyGroups[company]) companyGroups[company] = {};
+        if(!companyGroups[company][event]) companyGroups[company][event] = [];
+        companyGroups[company][event].push({space,ftype,pas,diffs,date:ev["Day of Event"]});
+      }
+    });
+
+    if(Object.keys(companyGroups).length === 0){
+      container.innerHTML = "<p style='opacity:.7'>✅ No changes detected between the reports.</p>";
+      return;
+    }
+
+    for(const company of Object.keys(companyGroups)){
+      const compHeader = document.createElement("div");
+      compHeader.className = "company-header";
+      compHeader.textContent = company;
+      container.appendChild(compHeader);
+
+      for(const event of Object.keys(companyGroups[company])){
+        const evHeader = document.createElement("div");
+        evHeader.className = "event-header";
+        evHeader.textContent = event;
+        container.appendChild(evHeader);
+
+        companyGroups[company][event].forEach(change=>{
+          const card = document.createElement("div");
+          card.className = "change-card";
+          card.innerHTML = `
+            <h4>${change.space} — ${change.ftype} ${change.pas?("· "+change.pas):""}</h4>
+            <div style="font-size:.8rem;color:#555;margin-bottom:4px;">${change.date}</div>
+            <ul>
+              ${change.diffs.map(d=>
+                `<li>${d.field}:
+                  <span class="change-prev">${d.prev}</span> →
+                  <span class="change-new">${d.newest}</span>
+                </li>`).join("")}
+            </ul>`;
+          container.appendChild(card);
+        });
+      }
+    }
+  }
+
+  // ---------- Today’s Forecast (Dashboard) - restored "What's Happening" style + dedup ----------
+  function renderForecast(){
+    const host = document.getElementById("forecast");
+    host.innerHTML = "";
+
+    if(!reportA.length){
+      host.innerHTML = "<p style='opacity:.8'>Upload the newest report to view today’s schedule summary.</p>";
+      return;
+    }
+
+    const now = new Date();
+    const todayISO = toLocalISODate(now);
+
+    // Filter to *today* only from newest report
+    const todays = reportA.filter(ev=>{
+      const d = parseDayOfEvent(ev["Day of Event"]);
+      return d && toLocalISODate(d) === todayISO;
+    });
+
+    if(!todays.length){
+      host.innerHTML = "<p style='opacity:.8'>No events scheduled for today.</p>";
+      return;
+    }
+
+    // --- Companies & Function Spaces (dedup spaces per event) ---
+    const companyEvents = {};
+    todays.forEach(ev=>{
+      const company = ev["Company Name"]||"";
+      const event   = ev["Event Name"]||"";
+      const space   = ev["Function Space"]||"";
+      if(!companyEvents[company]) companyEvents[company] = {};
+      if(!companyEvents[company][event]) companyEvents[company][event] = new Set();
+      companyEvents[company][event].add(space);
+    });
+
+    const compCard = document.createElement("div");
+    compCard.className = "forecast-card";
+    compCard.innerHTML = "<h3>Companies & Function Spaces</h3>";
+    Object.entries(companyEvents).forEach(([company, events])=>{
+      const group = document.createElement("div");
+      group.className = "company-group";
+      group.innerHTML = `<div class="company-name">${company}</div>`;
+      Object.entries(events).forEach(([event, spaceSet])=>{
+        const spaces = Array.from(spaceSet);
+        const evBlock = document.createElement("div");
+        evBlock.className = "event-block";
+        evBlock.innerHTML = `
+          <div class="event-title">${event}</div>
+          <div>${spaces.map(s=>`<span class="space-pill">${s}</span>`).join("")}</div>`;
+        group.appendChild(evBlock);
+      });
+      compCard.appendChild(group);
+    });
+    host.appendChild(compCard);
+
+    // Build normalized entries for happening & warnings
+    const entries = todays.map(ev=>{
+      const d = parseDayOfEvent(ev["Day of Event"]);
+      const [sh,sm] = parseTime(ev["Start Time"]);
+      const [eh,em] = parseTime(ev["End Time"]);
+      return {
+        company: ev["Company Name"]||"",
+        event: ev["Event Name"]||"",
+        space: ev["Function Space"]||"",
+        start: new Date(d.getFullYear(), d.getMonth(), d.getDate(), sh, sm),
+        end:   new Date(d.getFullYear(), d.getMonth(), d.getDate(), eh, em),
+      };
+    }).sort((a,b)=>a.start-b.start);
+
+    // Happening sections (restored row style)
+    const happeningCard = document.createElement("div");
+    happeningCard.className = "forecast-card happening";
+    happeningCard.innerHTML = "<h3>What's Happening</h3>";
+
+    const nowList = entries.filter(e => now >= e.start && now <= e.end);
+    const nextList = entries.filter(e => e.start > now).slice(0,4);
+
+    const renderSection = (title,list,cls)=>{
+      const sec = document.createElement("div");
+      sec.className = `section ${cls}`;
+      sec.innerHTML = `<strong>${title}</strong>`;
+      if(!list.length){
+        sec.innerHTML += `<p style='opacity:.7;font-size:.85rem'>No events</p>`;
+      } else {
+        list.forEach(e=>{
+          const row = document.createElement("div");
+          row.className = "happening-row";
+          row.innerHTML = `<span><b>${e.company}</b> — ${e.space}</span><span>${formatAMPM(e.start)} – ${formatAMPM(e.end)}</span>`;
+          sec.appendChild(row);
+        });
+      }
+      happeningCard.appendChild(sec);
+    };
+    renderSection("Now", nowList, "now");
+    renderSection("Next", nextList, "next");
+    host.appendChild(happeningCard);
+
+    // Warnings block (<=30 min flips between different companies in same room)
+    const byRoom = {};
+    entries.forEach(e=>{ (byRoom[e.space] ||= []).push(e); });
+    const flips = [];
+    Object.values(byRoom).forEach(list=>{
+      list.sort((a,b)=>a.start-b.start);
+      for(let i=1;i<list.length;i++){
+        const prev = list[i-1], curr = list[i];
+        const gap = (curr.start - prev.end)/60000;
+        if(gap>=0 && gap<=30 && prev.company!==curr.company){
+          flips.push({room:curr.space, prev, curr, gap});
+        }
+      }
+    });
+    if(flips.length){
+      const warnBlock = document.createElement("div");
+      warnBlock.className = "warnings-block";
+      warnBlock.innerHTML = "<h3>Warnings: Quick Room Flips</h3>";
+      flips.forEach(f=>{
+        const box = document.createElement("div");
+        box.className = "warning-box";
+        box.innerHTML = `
+          <strong>${f.room}</strong>
+          ${f.prev.company} (${formatAMPM(f.prev.start)} – ${formatAMPM(f.prev.end)}) → 
+          ${f.curr.company} (${formatAMPM(f.curr.start)} – ${formatAMPM(f.curr.end)})
+        `;
+        warnBlock.appendChild(box);
+      });
+      host.appendChild(warnBlock);
+    }
+  }
+
+  // ---------- File ingestion ----------
+  function ingestRows(target, rawRows){
+    const rows = (rawRows || []).filter(r=>r && r["Day of Event"]);
+    if(target === "A"){
+      reportA = rows;
+      allEvents = rows;
+      const todayISO = toLocalISODate(new Date());
+      const dp = document.getElementById("dayPicker");
+      if(dp) dp.value = todayISO;
+      if(google?.charts) drawChart(todayISO);
+      renderForecast();
+    } else {
+      reportB = rows;
+    }
+    if(reportA.length && reportB.length){
+      generateChangeLog(reportA, reportB);
+    }
+  }
+
+  function loadCSV(file, target){
+    return new Promise((resolve, reject)=>{
+      Papa.parse(file,{
+        header:true,
+        complete:(results)=>{
+          try {
+            ingestRows(target, results.data || []);
+            resolve();
+          } catch(err){
+            reject(err);
+          }
+        },
+        error:(err)=>reject(err)
+      });
+    });
+  }
+
+  async function extractPdfLines(file){
+    if(!window.pdfjsLib){
+      throw new Error("PDF.js library is not available");
+    }
+    const data = await file.arrayBuffer();
+    const pdf = await window.pdfjsLib.getDocument({data}).promise;
+    const lines = [];
+
+    for(let pageNum=1; pageNum<=pdf.numPages; pageNum++){
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      const items = textContent.items
+        .map(item=>({
+          text: (item.str || "").trim(),
+          x: item.transform?.[4] ?? 0,
+          y: item.transform?.[5] ?? 0
+        }))
+        .filter(item=>item.text);
+
+      items.sort((a,b)=>{
+        const yDiff = Math.abs(b.y - a.y);
+        if(yDiff > 2){
+          return b.y - a.y; // top to bottom
+        }
+        return a.x - b.x; // left to right
+      });
+
+      let currentY = null;
+      let parts = [];
+      items.forEach(item=>{
+        if(currentY === null || Math.abs(item.y - currentY) <= 2){
+          parts.push(item.text);
+          currentY = item.y;
+        } else {
+          const normalized = parts.join(' ').replace(/\s+/g,' ').trim();
+          if(normalized) lines.push(normalized);
+          parts = [item.text];
+          currentY = item.y;
+        }
+      });
+      if(parts.length){
+        const normalized = parts.join(' ').replace(/\s+/g,' ').trim();
+        if(normalized) lines.push(normalized);
+      }
+    }
+
+    return lines;
+  }
+
+  async function loadPDF(file, target){
+    const lines = await extractPdfLines(file);
+    const rows = [];
+
+    let currentCompany = null;
+    let currentEvent = null;
+    let currentDateStr = null;
+    let currentStatus = null;
+    let inEventHeader = false;
+    let inEventBody = false;
+    const lastSpaceByEvent = new Map();
+
+    for(const rawLine of lines){
+      const line = rawLine.trim();
+      if(!line){
+        continue;
+      }
+
+      if(line.includes("Quote #:")){
+        currentCompany = line.split("Quote #:")[0].trim();
+        inEventHeader = true;
+        inEventBody = false;
+        continue;
+      }
+
+      if(line.includes("Status:")){
+        const statusMatch = line.match(/Status:\s*(\w+)/i);
+        if(statusMatch){
+          currentStatus = statusMatch[1].trim();
+        }
+        continue;
+      }
+
+      if(line.includes("Folio #:")){
+        const evMatch = line.match(/(.+?)\s+Folio #:/);
+        if(evMatch){
+          currentEvent = evMatch[1].trim();
+          inEventHeader = true;
+          inEventBody = false;
+        }
+        continue;
+      }
+
+      if(DATE_LINE_RE.test(line)){
+        currentDateStr = line.trim();
+        continue;
+      }
+
+      const postMatch = line.match(POST_AS_RE);
+      if(postMatch && rows.length && inEventBody){
+        const last = rows[rows.length-1];
+        if(last["Function Space"] && !last["Post As"]){
+          last["Post As"] = postMatch[1].trim();
+        }
+        continue;
+      }
+      if(postMatch && inEventHeader){
+        continue;
+      }
+
+      const timeMatch = line.match(TIME_RANGE_RE);
+      if(!timeMatch){
+        continue;
+      }
+
+      inEventHeader = false;
+      inEventBody = true;
+
+      const startTime = cleanTimeString(timeMatch[1]);
+      const endTime = cleanTimeString(timeMatch[2]);
+      const functionType = detectFunctionType(line);
+      const setupStyle = detectSetupStyle(line);
+      let functionSpace = detectSpace(line);
+      functionSpace = expandGroupedSpace(line, functionSpace);
+
+      if(functionSpace && COUNTS_RE.test(functionSpace.trim())){
+        functionSpace = null;
+      }
+
+      const eventKey = `${currentCompany || ""}||${currentEvent || ""}`;
+      if(!functionSpace && functionType && FALLBACK_TYPES.has(functionType)){
+        const lastSpace = lastSpaceByEvent.get(eventKey);
+        if(lastSpace){
+          functionSpace = lastSpace;
+        }
+      }
+
+      if(!functionSpace){
+        continue;
+      }
+
+      lastSpaceByEvent.set(eventKey, functionSpace);
+
+      rows.push({
+        "Company Name": currentCompany || "",
+        "Event Name": currentEvent || "",
+        "Event Status": currentStatus || "",
+        "Day of Event": currentDateStr || "",
+        "Start Time": startTime,
+        "End Time": endTime,
+        "Function Type": functionType || "",
+        "Function Space": functionSpace || "",
+        "Setup Style": setupStyle || "",
+        "Post As": "",
+        "Raw Line": line
+      });
+    }
+
+    ingestRows(target, rows);
+    return rows;
+  }
+
+  function isPdfFile(file){
+    const type = (file.type || "").toLowerCase();
+    const name = (file.name || "").toLowerCase();
+    return type === "application/pdf" || name.endsWith(".pdf");
+  }
+
+  async function processUpload(file, target){
+    try {
+      if(isPdfFile(file)){
+        const rows = await loadPDF(file, target);
+        if(!rows.length){
+          alert(`No events were recognized in ${file.name}.`);
+        }
+      } else {
+        await loadCSV(file, target);
+      }
+    } catch(err){
+      console.error(err);
+      alert(`Unable to parse ${file.name}: ${err?.message || err}`);
+    }
+  }
+
+  // ---------- Date controls ----------
+  function updateDate(){
+    const d=document.getElementById("dayPicker").value;
+    if(d) drawChart(d);
+  }
+  function changeDay(offset){
+    if(!currentDate)return;
+    const nd=new Date(currentDate); nd.setDate(currentDate.getDate()+offset);
+    const localDate=toLocalISODate(nd);
+    document.getElementById("dayPicker").value=localDate;
+    drawChart(localDate);
+  }
+  function toggleRooms(){
+    showAllRooms=!showAllRooms;
+    document.getElementById("toggleShowRooms").textContent=showAllRooms?"Hide Unused Rooms":"Show All Rooms";
+    if(currentDate) drawChart(toLocalISODate(currentDate));
+  }
+
+  // ---------- Tabs ----------
+  function activateTab(tabId){
+    document.querySelectorAll(".tab-btn").forEach(b=>b.classList.remove("active"));
+    document.querySelectorAll(".tab-content").forEach(c=>c.classList.remove("active"));
+    document.querySelector(`.tab-btn[data-tab="${tabId}"]`).classList.add("active");
+    document.getElementById(tabId).classList.add("active");
+    if(tabId==="forecastTab") renderForecast();
+  }
+
+  // ---------- Init ----------
+  google.charts.setOnLoadCallback(()=>{
+    // Global uploads work from any tab
+    document.getElementById("csvFileA").addEventListener("change",e=>{
+      const f=e.target.files[0];
+      if(f) processUpload(f,"A");
+    });
+    document.getElementById("csvFileB").addEventListener("change",e=>{
+      const f=e.target.files[0];
+      if(f) processUpload(f,"B");
+    });
+
+    // Timeline controls
+    document.getElementById("dayPicker").addEventListener("change",updateDate);
+    document.getElementById("prevDay").addEventListener("click",()=>changeDay(-1));
+    document.getElementById("nextDay").addEventListener("click",()=>changeDay(1));
+    document.getElementById("toggleShowRooms").addEventListener("click",toggleRooms);
+
+    // Tabs
+    document.querySelectorAll(".tab-btn").forEach(btn=>{
+      btn.addEventListener("click", ()=> activateTab(btn.dataset.tab));
+    });
+
+    // Resize handler
+    window.addEventListener("resize", ()=>{
+      if(currentDate) drawChart(toLocalISODate(currentDate));
+    });
+
+    // Default date = today (empty chart until CSV uploaded)
+    const todayISO = toLocalISODate(new Date());
+    document.getElementById("dayPicker").value = todayISO;
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `eventscope_pdf.html` variant of the dashboard that includes pdf.js for direct PDF uploads
- port the Python PDF parsing heuristics to JavaScript so PDFs populate the same timeline/change log/forecast views
- accept either CSV or PDF for both upload slots and share ingestion/error handling between formats

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd42a529908325b5cdc40741f3a0a4