### PR TITLE
Clarify timeline hAxis gridline configuration

### DIFF
--- a/EventScope v1.5.html
+++ b/EventScope v1.5.html
@@ -1348,6 +1348,7 @@
                     },
                     baselineColor: "#aaa",
                     gridlines: {
+                        // Only specify the gridline color so the ticks array controls the spacing.
                         color: "#ddd"
                     },
                     minorGridlines: {


### PR DESCRIPTION
## Summary
- note directly in drawDaily that only the gridline color is specified so the ticks array controls spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd760fa7208325ad5119c38b6fc410